### PR TITLE
菜鸟裹裹 -> 菜鸟

### DIFF
--- a/data/快递物流/菜鸟裹裹.yaml
+++ b/data/快递物流/菜鸟裹裹.yaml
@@ -1,5 +1,5 @@
 basic:
-  organization: 菜鸟裹裹
+  organization: 菜鸟
   cellPhone:
     - 4001787878
-  url: https://www.guoguo-app.com/
+  url: https://www.cainiao.com


### PR DESCRIPTION
菜鸟裹裹是菜鸟子品牌，还有菜鸟驿站等子品牌，因此改为「菜鸟」可能较为合适。