### PR TITLE
添加 CardDav 服务器 Radicale 输出格式的支持

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ temp
 public
 *.zip
 .DS_Store
+radicale

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "scripts": {
     "build": "npm run gulp build",
+    "radicale": "npm run gulp radicale",
     "gulp": "gulp --gulpfile src/gulpfile.js --cwd ./",
     "test": "npx ava src/test.js"
   },

--- a/src/gulpfile.js
+++ b/src/gulpfile.js
@@ -8,10 +8,18 @@ import rename from 'gulp-rename'
 import concatFolders from 'gulp-concat-folders'
 
 import plugin_vcard from './plugins/vcard.js'
+import plugin_vcard_ext from './plugins/vcard-ext.js'
 
 const generator = () => {
   return gulp.src('data/*/*.yaml')
     .pipe(through2.obj(plugin_vcard))
+    .pipe(rename({ extname: '.vcf' }))
+    .pipe(gulp.dest('./temp'))
+}
+
+const generator_ext = () => {
+  return gulp.src('data/*/*.yaml')
+    .pipe(through2.obj(plugin_vcard_ext))
     .pipe(rename({ extname: '.vcf' }))
     .pipe(gulp.dest('./temp'))
 }
@@ -42,12 +50,36 @@ const clean = () => {
   ])
 }
 
+const createRadicale = () => {
+  let folders = fs.readdirSync('temp')
+    .filter(function(f) {
+      return fs.statSync(path.join('temp', f)).isDirectory();
+    })
+  folders.map(function(folder){
+    fs.writeFileSync(path.join('temp', folder, '/.Radicale.props'), '{"D:displayname": "' + folder + '", "tag": "VADDRESSBOOK"}')
+  })
+  return gulp.src('temp/**', {})
+}
+
+const cleanRadicale = () => {
+  return del([
+    'radicale'
+  ], {force: true})
+}
+
+const distRadicale = () => {
+  return gulp.src('temp/**', {dot: true})
+    .pipe(gulp.dest('./radicale'))
+}
+
 const build = gulp.series(clean, generator, combine, allinone, archive)
+const radicale = gulp.series(clean, generator_ext, createRadicale, cleanRadicale, distRadicale)
 
 export {
   generator,
   combine,
   allinone,
   archive,
-  build
+  build,
+  radicale
 }

--- a/src/gulpfile.js
+++ b/src/gulpfile.js
@@ -1,3 +1,4 @@
+import fs from 'fs'
 import del from 'del'
 import through2 from 'through2'
 

--- a/src/plugins/vcard-ext.js
+++ b/src/plugins/vcard-ext.js
@@ -24,7 +24,7 @@ const plugin = (file, _, cb) => {
 
   let rev = new Date(Math.max(new Date(lastYamlChangeDateString), new Date(lastPngChangeDateString))).toISOString()
   
-  formatted = vCard.getFormattedString()
+  let formatted = vCard.getFormattedString()
   formatted = formatted.replace(/REV:[\d\-:T\.Z]+/, 'REV:' + rev)
   file.contents = Buffer.from(formatted)
   cb(null, file)

--- a/src/plugins/vcard-ext.js
+++ b/src/plugins/vcard-ext.js
@@ -1,0 +1,33 @@
+import fs from 'fs'
+import yaml from 'js-yaml'
+import vCardsJS from 'vcards-js'
+import {execSync} from 'child_process'
+
+const plugin = (file, _, cb) => {
+  const path = file.path
+  const data = fs.readFileSync(path, 'utf8')
+  const json = yaml.load(data)
+
+  let vCard = vCardsJS()
+  vCard.isOrganization = true
+  for (const [key, value] of Object.entries(json.basic)) {
+    vCard[key] = value
+  }
+
+  if (!vCard.uid){
+    vCard.uid = vCard.organization
+  }
+  
+  vCard.photo.embedFromFile(path.replace('.yaml', '.png'))
+  let lastYamlChangeDateString = execSync('git log -1 --pretty="format:%ci" ' + path).toString().trim().replace(/\s\+\d+/, '')
+  let lastPngChangeDateString = execSync('git log -1 --pretty="format:%ci" ' + path.replace('.yaml', '.png')).toString().trim().replace(/\s\+\d+/, '')
+
+  let rev = new Date(Math.max(new Date(lastYamlChangeDateString), new Date(lastPngChangeDateString))).toISOString()
+  
+  formatted = vCard.getFormattedString()
+  formatted = formatted.replace(/REV:[\d\-:T\.Z]+/, 'REV:' + rev)
+  file.contents = Buffer.from(formatted)
+  cb(null, file)
+}
+
+export default plugin


### PR DESCRIPTION
[Radicale](https://github.com/Kozea/Radicale) 是一个开源的 CalDav 和 CardDav 服务器软件，可凭 vcf 文件对外提供 CardDav 同步服务。但其对 vcf 文件有字段要求，以及需要在目录中包含属性文件。因此添加了 `src/plugin/vcard-ext.js` 来实现补充字段；并添加编译任务 `radicale` 以创建属性文件。

只需运行：

```bash
npm run-script radicale
```

即可在 radicale 目录中输出符合 Radicale 需求的数据文件。

关于 CardDav 的需求，可见 #208 、#50。关于 Radicale 与 vCards 结合使用可见 [为 vCards 搭建 Radicale CardDav 服务器](https://dallas.lu/radicale-server-for-vcards)

通过支持 Radicale 格式的输出文件，也可为未来输出更多格式、支持其他 CardDav 服务软件及实现部分特殊需求（如 #210）提供参考。