### PR TITLE
新增多个联系人内容

### DIFF
--- a/data/旅游出行/酒店住宿/万豪 Marriott/万豪酒店.yaml
+++ b/data/旅游出行/酒店住宿/万豪 Marriott/万豪酒店.yaml
@@ -1,0 +1,13 @@
+basic:
+  organization: 万豪（中国）预定中心
+  cellPhone:
+    - 中国大陆-预订（移动）：4006886886
+    - 中国香港：85230181475
+    - 中国澳门：85368570534
+    - 中国台湾：08090929231
+    - 中国大陆-客服：4006889889
+    - 中国大陆-预订（固定）：4006663197
+  url: https://www.marriott.com.cn/
+  email:
+    address: cncontentsupport@marriott.com
+    label: 中国大陆


### PR DESCRIPTION
## 📝 更新内容

此次更新主要添加了：

* **万豪Marriott集团国内外客户服务及预定中心联系方式**：
  - 预订电话（移动/固定）
  - 客服电话
  - 官方网站与邮箱信息

* **数家万豪旗下酒店的详细联系信息**：
  - 主要为北京部分酒店
  - 包含酒店直拨电话和服务信息
  - 支持随时查询和拨打
  - 经过实地测试
  
* **细化分类目录**:
  - 将出行目录更改为“旅游出行”
  - 增加“酒店住宿”“航空铁路”两个子目录
  - “酒店住宿”细化为各家酒店集团

---


## 💡 用户价值

这些联系方式可帮助用户在**预订和入住过程中快速联系酒店**，优化通讯录体验。所有数据均已经过验证，确保**准确可用**。

适合商旅人士、旅游爱好者及需要经常预订酒店的用户使用。
