### PR TITLE
feat: 添加立创商城邮箱

### DIFF
--- a/data/电商购物/立创商城.yaml
+++ b/data/电商购物/立创商城.yaml
@@ -2,4 +2,9 @@ basic:
   organization: 立创商城
   cellPhone:
     - 0755-83865666
+  workMail:
+    - email: aservice@szlcsc.com
+      label: 通知
+    - email: ic@szlcsc.com
+      label: 支持
   url: https://www.szlcsc.com

--- a/data/电商购物/立创商城.yaml
+++ b/data/电商购物/立创商城.yaml
@@ -2,7 +2,7 @@ basic:
   organization: 立创商城
   cellPhone:
     - 0755-83865666
-  workMail:
+  workEmail:
     - email: aservice@szlcsc.com
       label: 通知
     - email: ic@szlcsc.com


### PR DESCRIPTION
邮箱地址并非笔误，官方就是“aservice”