### PR TITLE
更新特斯拉服务热线

### DIFF
--- a/data/汽车行业/特斯拉.yaml
+++ b/data/汽车行业/特斯拉.yaml
@@ -1,6 +1,5 @@
 basic:
   organization: 特斯拉
   cellPhone:
-    - 4009190707
     - 4009100707
   url: https://www.tesla.cn/


### PR DESCRIPTION
## 变更内容

- 移除特斯拉已停用的服务热线 `4009190707`
- 保留当前全国服务热线 `4009100707`

## 原因与影响

特斯拉已通知全国服务热线变更为 `400-910-0707`。此前数据仍包含旧号码，可能导致用户拨打无效服务电话。本次更新后生成的 vCard 将只包含有效号码。

## 验证

- 核对变更仅涉及 `data/汽车行业/特斯拉.yaml`
- 确认分支相对 `master` 仅删除 1 行，未修改其他联系人数据
- PR 的 Check 工作流将运行 `npm install` 与 `npm test`

Fixes #796