### PR TITLE
harden: avoid shell execution in vcard-ext git calls

### DIFF
--- a/src/plugins/vcard-ext.js
+++ b/src/plugins/vcard-ext.js
@@ -1,7 +1,7 @@
 import fs from 'fs'
 import yaml from 'js-yaml'
 import vCardsJS from 'vcards-js'
-import {execSync} from 'child_process'
+import {execFileSync} from 'child_process'
 import addPhoneticField from '../utils/pinyin.js'
 
 const plugin = (file, _, cb) => {
@@ -44,8 +44,8 @@ const plugin = (file, _, cb) => {
   }
 
   vCard.photo.embedFromFile(path.replace('.yaml', '.png'))
-  let lastYamlChangeDateString = execSync(`git log -1 --pretty="format:%ci" "${path}"`).toString().trim().replace(/\s\+\d+/, '')
-  let lastPngChangeDateString = execSync(`git log -1 --pretty="format:%ci" "${path.replace('yaml', 'png')}"`).toString().trim().replace(/\s\+\d+/, '')
+  let lastYamlChangeDateString = execFileSync('git', ['log', '-1', '--pretty=format:%ci', '--', path]).toString().trim().replace(/\s\+\d+/, '')
+  let lastPngChangeDateString = execFileSync('git', ['log', '-1', '--pretty=format:%ci', '--', path.replace('yaml', 'png')]).toString().trim().replace(/\s\+\d+/, '')
 
   let rev = new Date(Math.max(new Date(lastYamlChangeDateString), new Date(lastPngChangeDateString))).toISOString()
 


### PR DESCRIPTION
## Summary

Replace shell-interpolated `git log` calls in `src/plugins/vcard-ext.js` with `execFileSync` argument arrays.

This is a corrected alternative to #798.

## Changes

- use `execFileSync` so file paths are not interpreted by a shell
- add `--` before each pathspec to terminate Git option parsing
- preserve synchronous failure behavior from the original `execSync` implementation
- preserve the existing CRLF delimiters in generated vCard email fields

## Impact

Valid inputs retain their existing behavior while file paths containing shell metacharacters can no longer become shell commands.

## Validation

- verified the branch is one commit ahead of `master`
- verified only `src/plugins/vcard-ext.js` changed (3 additions, 3 deletions)
- verified both labeled-email lines retain CRLF bytes

CI should provide the repository test result.